### PR TITLE
Remove default argument of friend function to compile on Mac OS

### DIFF
--- a/README
+++ b/README
@@ -26,9 +26,13 @@ The web site of the Omega Project remains at
 but the source code is now on github.com:
 
 	http://github.com/davewathaverford/the-omega-project/
+	
+I fix some incompatiblities with the latest Xcode on Mac OS in my fork of the repository:
+
+	https://github.com/qsphan/the-omega-project
 
 To obtain a read-only copy of the source code on linux or MacOS
 with a command-line git client, use the command
 
-	git clone git://github.com/davewathaverford/the-omega-project
+	git clone git://github.com/qsphan/the-omega-project
 

--- a/omega_lib/include/omega/pres_conj.h
+++ b/omega_lib/include/omega/pres_conj.h
@@ -263,7 +263,7 @@ private:
   friend int       simplify_conj(Conjunct* conj, int ver_sim, int elim_red, int color);
   friend DNF*      negate_conj(Conjunct* conj);
   friend Conjunct* merge_conjs(Conjunct* conj1, Conjunct* conj2,
-			      Merge_Action action, Rel_Body *body = 0);
+			      Merge_Action action, Rel_Body *body);
   friend void      copy_conj_header(Conjunct* to, Conjunct* fr);
 
 

--- a/omega_lib/src/pres_beaut.c
+++ b/omega_lib/src/pres_beaut.c
@@ -168,7 +168,7 @@ void F_And::beautify()
 		{
 		Conjunct *conj1 = merge_conjs(conj,
 					     f->really_conjunct(),
-					     MERGE_REGULAR);
+					     MERGE_REGULAR,0);
 		delete f;
 		delete conj;
 		conj = conj1;

--- a/omega_lib/src/pres_dnf.c
+++ b/omega_lib/src/pres_dnf.c
@@ -97,7 +97,7 @@ void DNF::rm_redundant_conjs(int effort) {
 	     }
 	  else {
 		
-	  Conjunct *cgist = merge_conjs(cdel, c, MERGE_GIST);
+	  Conjunct *cgist = merge_conjs(cdel, c, MERGE_GIST, 0);
 
 	  if (!cgist->redSimplifyProblem(effort,0)) {
 	    if(pres_debug) {
@@ -314,7 +314,7 @@ void DNF::clear()
 DNF* DNF_and_conj(DNF* dnf, Conjunct* conj) {
   DNF* new_dnf = new DNF;
   for(DNF_Iterator p(dnf); p.live(); p.next()) {
-    Conjunct* new_conj = merge_conjs(p.curr(), conj, MERGE_REGULAR);
+    Conjunct* new_conj = merge_conjs(p.curr(), conj, MERGE_REGULAR, 0);
     new_dnf->add_conjunct(new_conj);
   }
   if(new_dnf->length() > 1) {
@@ -364,7 +364,7 @@ DNF* conj_and_not_dnf(Conjunct *positive_conjunct, DNF *neg_conjs, bool weak) {
 	p.curr_set(NULL);
 	continue;
 	}
-	  Conjunct *cgist = merge_conjs(positive_conjunct, neg_conj, MERGE_GIST);
+	  Conjunct *cgist = merge_conjs(positive_conjunct, neg_conj, MERGE_GIST, 0);
           if(simplify_conj(cgist, false, true, _red) == false) 
 	      {
 	      delete cgist;
@@ -389,7 +389,7 @@ DNF* conj_and_not_dnf(Conjunct *positive_conjunct, DNF *neg_conjs, bool weak) {
 	              delete cgist;
 	              Conjunct *conj =
 	              merge_conjs(positive_conjunct, neg_dnf->single_conjunct(), 
-				  MERGE_REGULAR);
+				  MERGE_REGULAR, 0);
 	              delete positive_conjunct;
 	              delete neg_dnf;
 	              positive_conjunct = conj;
@@ -795,7 +795,7 @@ DNF* F_And::DNFize()
 			}
 		    else 
 			{
-			Conjunct *new_conj = merge_conjs(positive_conjunct, conj, MERGE_REGULAR);
+			Conjunct *new_conj = merge_conjs(positive_conjunct, conj, MERGE_REGULAR, 0);
 			delete conj;
 			delete positive_conjunct;
 			positive_conjunct = new_conj;

--- a/petit/include/petit/Zima.h
+++ b/petit/include/petit/Zima.h
@@ -67,13 +67,13 @@ public:
 // If already_done != NULL, stop adding constraints when we get there
 
     friend void access_in_bounds(F_And *N, const AccessIteration &AI,
-				 context_iterator already_done = 0,
-				 bool assertions = true);
+				 context_iterator already_done,
+				 bool assertions);
 
     friend void context_in_bounds(F_And *N, const AccessIteration &AI,
 				 context_iterator c,
-				 context_iterator already_done = 0,
-				 bool assertions = true);
+				 context_iterator already_done,
+				 bool assertions);
 
 //
 // For A[I] and B[J] to access the same memory location,
@@ -86,7 +86,7 @@ public:
 //
     friend void access_same_memory(F_And *N, const AccessIteration &AI,
 				   const AccessIteration &BJ);
-    
+
     friend void subscripts_equal_to_tuple (F_And *N, const AccessIteration &AI,
                                 const Variable_ID_Tuple *t);
 

--- a/petit/src/add-assert.c
+++ b/petit/src/add-assert.c
@@ -110,11 +110,11 @@ build_zap_problem(dd_current dd, Relation *r)
 
     context_iterator c = cont_i_for_access(src.access());
     while (!cont_i_done(c) && !cont_i_cur_is_loop(c)) cont_i_next(c);
-    if (!cont_i_done(c)) context_in_bounds(le, src, c);
+    if (!cont_i_done(c)) context_in_bounds(le, src, c, 0, true);
 
     c = cont_i_for_access(dest.access());
     while (!cont_i_done(c) && !cont_i_cur_is_loop(c)) cont_i_next(c);
-    if (!cont_i_done(c)) context_in_bounds(le, dest, c);
+    if (!cont_i_done(c)) context_in_bounds(le, dest, c, 0, true);
 
     assert(copy(loops_execute).is_upper_bound_satisfiable());
 

--- a/petit/src/browsedd.c
+++ b/petit/src/browsedd.c
@@ -637,8 +637,8 @@ void write_deps(char *filename , char *inputfile,
 					
 					F_And *f = it.add_and();
 					
-					access_in_bounds(f, a);
-					access_in_bounds(f, b);
+					access_in_bounds(f, a, 0, true);
+					access_in_bounds(f, b, 0, true);
 					it.finalize();
 
 					it = Intersection(it,

--- a/petit/src/build_stmt_rel.c
+++ b/petit/src/build_stmt_rel.c
@@ -197,7 +197,7 @@ static Relation buildBoundsSet(int stmt)
 
  F_And *f = it.add_and();
 
- access_in_bounds(f, a1);
+ access_in_bounds(f, a1, 0, true);
  it.finalize();
  it.simplify(1,1); 
  return it;
@@ -218,8 +218,8 @@ static Relation getBoundsRelation(int stmt1, int stmt2)
 
 // unify_symbolic_constants(f, a1, a2, 0);
        
- access_in_bounds(f, a1);
- access_in_bounds(f, a2);
+ access_in_bounds(f, a1, 0, true);
+ access_in_bounds(f, a2, 0, true);
  it.finalize();
  it.simplify(1,1); 
  return it;

--- a/petit/src/ddomega.c
+++ b/petit/src/ddomega.c
@@ -109,8 +109,8 @@ static Relation memory_dependence_relation(a_access access1, a_access access2)
 
     F_And *f = it.add_and();
 
-    access_in_bounds(f, a);
-    access_in_bounds(f, b);
+    access_in_bounds(f, a, 0, true);
+    access_in_bounds(f, b, 0, true);
     access_same_memory(f, a, b);
     it.finalize();
 
@@ -181,7 +181,7 @@ void dd_omega_test(a_access access1, a_access access2,
         if (access1!=Entry) {
            assert (access2 == ExitNode);
   	   AccessIteration a(access1,simple_rel, Input_Tuple);
-           access_in_bounds(f,a);
+           access_in_bounds(f,a,0,true);
            subscripts_equal_to_tuple(f, a, &output_vars);
            } 
 
@@ -189,7 +189,7 @@ void dd_omega_test(a_access access1, a_access access2,
         if (access2!=ExitNode) {
            assert (access1 == Entry);
            AccessIteration b(access2,simple_rel, Output_Tuple);
-  	   access_in_bounds(f, b);
+  	   access_in_bounds(f, b, 0, true);
            subscripts_equal_to_tuple(f, b, &input_vars);
 	 }
 

--- a/petit/src/hpp.c
+++ b/petit/src/hpp.c
@@ -139,7 +139,7 @@ Relation get_is(node *n) {
     Relation R(node_depth(a));
     AccessIteration ai(a, &R, Input_Tuple);
     F_And *f = R.add_and();
-    access_in_bounds(f, ai);
+    access_in_bounds(f, ai, 0, true);
     R.finalize();
     return R;
 }

--- a/petit/src/kill.c
+++ b/petit/src/kill.c
@@ -146,7 +146,7 @@ static Relation build_initial_exposed(a_access access1)
 
   F_And *f = it.add_and();
 
-  access_in_bounds(f,a);
+  access_in_bounds(f,a,0,true);
   it.finalize();
   return it;
 
@@ -298,7 +298,7 @@ static change do_simple_kill(Relation &value_deps,
 			already_done = access_inner_shared_context_at_depth(B, A, C, lzo);
 			}
 
-		    access_in_bounds(fkf, bj2, already_done);
+		    access_in_bounds(fkf, bj2, already_done, true);
 		    access_same_memory(fkf, bj2, ck);
 		    connected_by_diff(fkf, bj2, ck, killer_flow);
 		    kf.finalize();


### PR DESCRIPTION
There is an error when compiling Omega on Mac due to the default argument on the function:
`friend Conjunct* merge_conjs((Conjunct* conj1, Conjunct* conj2, Merge_Action action, Rel_Body *body = 0);` 

More details about the error can be found here:
http://stackoverflow.com/questions/22533511/friend-declaration-specifying-a-default-argument-must-be-a-definition

I removed the default argument of the function `merge_conjs`, and pass the argument explicitly wherever it is invoked.
